### PR TITLE
fix(db): prevent trigger errors + add db:test script

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -14,6 +14,7 @@
     "db:push": "supabase db push",
     "db:pull": "supabase db pull",
     "db:migrate": "supabase migration new",
+    "db:test": "supabase test db",
     "db:types": "supabase gen types typescript --local > packages/shared/supabase/db/types.ts"
   },
   "dependencies": {


### PR DESCRIPTION
- Trigger: Access old.deleted_at only on comments table to prevent errors
on profiles and reactions (which don't have that column)
- Add db:test script for running pgTAP database tests

Notes:
- Fixes trigger error: "record variable old has no column deleted_at"
- The trigger now checks TG_TABLE_NAME before accessing deleted_at
- db:test runs all pgTAP tests in supabase/tests/database/
- All 152 tests pass