### PR TITLE
chore(db): establish newsletter subscriptions baseline

### DIFF
--- a/apps/server/supabase/migrations/20260222101638_create_newsletter_subscriptions.sql
+++ b/apps/server/supabase/migrations/20260222101638_create_newsletter_subscriptions.sql
@@ -1,0 +1,43 @@
+/*
+TABLE: public.newsletter_subscriptions
+
+ROLE IN THE SYSTEM:
+  Stores newsletter subscriber emails with verification tokens.
+  Supports double opt-in flow (verification required before active).
+
+CORE INVARIANTS (DO NOT VIOLATE):
+  - One subscription per email (unique constraint on email).
+  - Tokens are single-use and must be consumed within 24 hours.
+  - Verified subscribers have confirmed ownership of the email.
+
+VERIFICATION FLOW (Authoritative):
+  1. User submits email → pending subscription created with token
+  2. Confirmation email sent with token link
+  3. User clicks link → token validated + email re-entry required
+  4. On match → subscription marked as verified
+
+SECURITY & PRIVACY:
+  - Email is PII - do not expose via API without consideration.
+  - Tokens are secrets - treat as single-use, expire after 24h.
+*/
+create table public.newsletter_subscriptions (
+  id uuid primary key default gen_random_uuid(),
+  email citext not null unique
+    check (
+      email ~* '^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$'
+    ),
+  token uuid not null unique default gen_random_uuid(),
+  verified boolean not null default false,
+  created_at timestamptz not null default now(),
+  verified_at timestamptz,
+  consumed_at timestamptz
+);
+
+-- Index for verification lookup
+create index if not exists newsletter_token_idx
+  on public.newsletter_subscriptions (token) 
+  where verified = false;
+
+-- Index for email lookup
+create index if not exists newsletter_email_idx
+  on public.newsletter_subscriptions (email);

--- a/apps/server/supabase/migrations/20260225100000_create_add_unsubscribed_at.sql
+++ b/apps/server/supabase/migrations/20260225100000_create_add_unsubscribed_at.sql
@@ -1,0 +1,12 @@
+/*
+SCHEMA: public.newsletter_subscriptions
+
+Add unsubscribed_at column for soft-delete unsubscribe functionality.
+
+This allows users to unsubscribe via token without requiring account login.
+The column tracks when a user voluntarily unsubscribed.
+*/
+set local lock_timeout = '10s'
+;
+alter table public.newsletter_subscriptions 
+add column if not exists unsubscribed_at timestamptz;

--- a/apps/server/supabase/migrations/20260225100001_create_rpc_verify_subscription.sql
+++ b/apps/server/supabase/migrations/20260225100001_create_rpc_verify_subscription.sql
@@ -1,0 +1,85 @@
+/*
+RPC: public.verify_subscription
+
+PURPOSE:
+  Verify a newsletter subscription via double opt-in flow.
+  Called when user clicks confirmation link and re-enters their email.
+
+SECURITY:
+  - Uses security definer to bypass RLS
+  - Sets search_path to prevent attacks
+  - Token expires after 24 hours
+  - Requires email re-entry for verification (prevents accidental/automated clicks)
+
+INPUT:
+  - p_token: UUID token from confirmation email
+  - p_email: User's email (re-entered for verification)
+
+ERROR CODES:
+  - P0001: Invalid token
+  - P0002: Already verified
+  - P0003: Token expired
+  - P0004: Token already used
+  - P0005: Email mismatch
+*/
+create or replace function public.verify_subscription(p_token uuid, p_email text)
+returns boolean
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_subscription record;
+  v_result boolean := false;
+begin
+  -- Find the subscription by token
+  select id, email, verified, created_at, consumed_at
+  into v_subscription
+  from public.newsletter_subscriptions
+  where token = p_token;
+
+  -- Check if subscription exists
+  if v_subscription.id is null then
+    raise exception 'Invalid token' using errcode = 'P0001';
+  end if;
+
+  -- Check if already verified
+  if v_subscription.verified then
+    raise exception 'Already verified' using errcode = 'P0002';
+  end if;
+
+  -- Check if token is expired (24 hours)
+  if v_subscription.created_at < now() - interval '24 hours' then
+    raise exception 'Token expired' using errcode = 'P0003';
+  end if;
+
+  -- Check if already consumed
+  if v_subscription.consumed_at is not null then
+    raise exception 'Token already used' using errcode = 'P0004';
+  end if;
+
+  -- Verify email re-entry matches (case-insensitive)
+  if lower(v_subscription.email) <> lower(p_email) then
+    raise exception 'Email mismatch' using errcode = 'P0005';
+  end if;
+
+  -- Mark as verified
+  update public.newsletter_subscriptions
+  set 
+    verified = true,
+    verified_at = now(),
+    consumed_at = now()
+  where id = v_subscription.id;
+
+  v_result := true;
+
+  return v_result;
+end;
+$$
+;
+
+-- Grant execute permission to anon and authenticated roles
+grant execute
+on function public.verify_subscription(uuid, text)
+to anon, authenticated
+;

--- a/apps/server/supabase/migrations/20260225100002_create_rpc_unsubscribe.sql
+++ b/apps/server/supabase/migrations/20260225100002_create_rpc_unsubscribe.sql
@@ -1,0 +1,65 @@
+/*
+RPC: public.unsubscribe
+
+PURPOSE:
+  Allow users to unsubscribe from newsletter via token-based link.
+  Implements soft-delete by marking subscription as unsubscribed.
+
+SECURITY:
+  - Uses security definer to bypass RLS
+  - Sets search_path to prevent attacks
+  - Token-based (no email exposed in URL)
+  - Single-use (token can only unsubscribe once)
+
+INPUT:
+  - p_token: UUID token from unsubscribe link in email
+
+ERROR CODES:
+  - P0001: Invalid token
+  - P0002: Already unsubscribed
+*/
+create or replace function public.unsubscribe(p_token uuid)
+returns boolean
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_subscription record;
+  v_result boolean := false;
+begin
+  -- Find the subscription by token
+  select id, email, verified, unsubscribed_at
+  into v_subscription
+  from public.newsletter_subscriptions
+  where token = p_token;
+
+  -- Check if subscription exists
+  if v_subscription.id is null then
+    raise exception 'Invalid token' using errcode = 'P0001';
+  end if;
+
+  -- Check if already unsubscribed
+  if v_subscription.unsubscribed_at is not null then
+    raise exception 'Already unsubscribed' using errcode = 'P0002';
+  end if;
+
+  -- Mark as unsubscribed (soft delete)
+  update public.newsletter_subscriptions
+  set 
+    verified = false,
+    unsubscribed_at = now()
+  where id = v_subscription.id;
+
+  v_result := true;
+
+  return v_result;
+end;
+$$
+;
+
+-- Grant execute permission to anon and authenticated roles
+grant execute
+on function public.unsubscribe(uuid)
+to anon, authenticated
+;

--- a/apps/server/supabase/migrations/20260225100003_policies_newsletter_select_service_role.sql
+++ b/apps/server/supabase/migrations/20260225100003_policies_newsletter_select_service_role.sql
@@ -1,0 +1,17 @@
+/*
+POLICY: newsletter_subscriptions_select_service_role
+PURPOSE:
+  - Service role only can SELECT (email privacy)
+  - No public read access to subscriber emails
+*/
+drop policy if exists "newsletter_subscriptions_select_public" on public.newsletter_subscriptions;
+drop policy if exists "newsletter_subscriptions_select_service_role" on public.newsletter_subscriptions;
+
+create policy "newsletter_subscriptions_select_service_role"
+  on public.newsletter_subscriptions for select
+  to service_role
+  using (true);
+
+set local lock_timeout = '10s'
+;
+alter table public.newsletter_subscriptions enable row level security;

--- a/apps/server/supabase/migrations/20260225100004_policies_newsletter_insert_public.sql
+++ b/apps/server/supabase/migrations/20260225100004_policies_newsletter_insert_public.sql
@@ -1,0 +1,14 @@
+/*
+POLICY: newsletter_subscriptions_insert_public
+
+PURPOSE:
+  - Anyone can subscribe (insert) - requiresAccount = false per plan
+  - verified=false is enforced by column default
+  - Prevents pre-verified subscriptions
+*/
+drop policy if exists "newsletter_subscriptions_insert_public" on public.newsletter_subscriptions;
+
+create policy "newsletter_subscriptions_insert_public"
+  on public.newsletter_subscriptions for insert
+  to anon, authenticated
+  with check (verified = false);

--- a/apps/server/supabase/migrations/20260225100005_policies_newsletter_update_blocked.sql
+++ b/apps/server/supabase/migrations/20260225100005_policies_newsletter_update_blocked.sql
@@ -1,0 +1,14 @@
+/*
+POLICY: newsletter_subscriptions_update_blocked
+
+PURPOSE:
+  - Block all direct UPDATE access
+  - Updates must go through RPC functions (verify_subscription, unsubscribe)
+*/
+drop policy if exists "newsletter_subscriptions_update_blocked" on public.newsletter_subscriptions;
+
+create policy "newsletter_subscriptions_update_blocked"
+  on public.newsletter_subscriptions for update
+  to anon, authenticated
+  using (false)
+  with check (false);

--- a/apps/server/supabase/migrations/20260225100006_policies_newsletter_delete_service_role.sql
+++ b/apps/server/supabase/migrations/20260225100006_policies_newsletter_delete_service_role.sql
@@ -1,0 +1,19 @@
+/*
+POLICY: newsletter_subscriptions_delete_service_role
+
+PURPOSE:
+  - DELETE only for service_role
+  - Regular users cannot delete subscriptions (soft-delete via unsubscribe RPC instead)
+*/
+drop policy if exists "newsletter_subscriptions_delete_service_role" on public.newsletter_subscriptions;
+drop policy if exists "newsletter_subscriptions_delete_blocked" on public.newsletter_subscriptions;
+
+create policy "newsletter_subscriptions_delete_blocked"
+  on public.newsletter_subscriptions for delete
+  to anon, authenticated
+  using (false);
+
+create policy "newsletter_subscriptions_delete_service_role"
+  on public.newsletter_subscriptions for delete
+  to service_role
+  using (true);


### PR DESCRIPTION
Establishes newsletter subscription system:
- **Table**: newsletter_subscriptions with double opt-in flow
- **RLS Policies**: privacy-first (service role only reads, public can subscribe)
- **RPC Functions**: verify_subscription, unsubscribe
- **Soft Delete**: unsubscribed_at column for GDPR-compliant opt-out

Testing:
- [x] Migrations apply successfully
- [x] RLS policies in place (no Advisor warnings)

Notes:
- Token-based unsubscribe (no account required)
- Emails are PII-protected via RLS
- One subscription per email (unique constraint)
- Tokens expire after 24 hours